### PR TITLE
Initialize NestJS chat skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# poc-chat-reddis-nestjs
+# Chat Application (NestJS)
+
+This project is a skeleton for a chat application built with NestJS, PostgreSQL and Prisma.
+
+## Features
+
+- One to one chat
+- Ready for group chats in the future
+- Fetch the last message between users
+- File sending support (stores file URL)
+- Designed for up to 10k concurrent users
+
+## Getting Started
+
+Install dependencies (requires internet access):
+
+```bash
+npm install
+```
+
+Generate the Prisma client and migrate the database:
+
+```bash
+npx prisma migrate dev
+```
+
+Run the development server:
+
+```bash
+npm run start:dev
+```
+
+Environment variables can be configured in a `.env` file. See `prisma/schema.prisma` for the `DATABASE_URL`.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "poc-chat-reddis-nestjs",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node dist/main.js",
+    "start:dev": "ts-node-dev --respawn src/main.ts",
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@nestjs/common": "latest",
+    "@nestjs/core": "latest",
+    "@nestjs/platform-express": "latest",
+    "@nestjs/websockets": "latest",
+    "@prisma/client": "latest",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0",
+    "ts-node-dev": "^2.0.0",
+    "prisma": "latest"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,27 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  messagesSent     Message[] @relation("messagesSent")
+  messagesReceived Message[] @relation("messagesReceived")
+}
+
+model Message {
+  id         Int      @id @default(autoincrement())
+  sender     User     @relation("messagesSent", fields: [senderId], references: [id])
+  senderId   Int
+  receiver   User     @relation("messagesReceived", fields: [receiverId], references: [id])
+  receiverId Int
+  content    String
+  fileUrl    String?
+  createdAt  DateTime @default(now())
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ChatModule } from './chat/chat.module';
+import { PrismaModule } from './prisma/prisma.module';
+
+@Module({
+  imports: [ChatModule, PrismaModule],
+})
+export class AppModule {}

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -1,0 +1,17 @@
+import { WebSocketGateway, WebSocketServer, SubscribeMessage, MessageBody } from '@nestjs/websockets';
+import { ChatService } from './chat.service';
+import { Server } from 'socket.io';
+
+@WebSocketGateway()
+export class ChatGateway {
+  @WebSocketServer()
+  server: Server;
+
+  constructor(private chatService: ChatService) {}
+
+  @SubscribeMessage('message')
+  async handleMessage(@MessageBody() data: { senderId: number; receiverId: number; content: string }) {
+    const message = await this.chatService.createMessage(data.senderId, data.receiverId, data.content);
+    this.server.emit(`message_${data.receiverId}`, message);
+  }
+}

--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { ChatGateway } from './chat.gateway';
+import { ChatService } from './chat.service';
+
+@Module({
+  providers: [ChatGateway, ChatService],
+})
+export class ChatModule {}

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { Message } from '@prisma/client';
+
+@Injectable()
+export class ChatService {
+  constructor(private prisma: PrismaService) {}
+
+  async createMessage(senderId: number, receiverId: number, content: string): Promise<Message> {
+    return this.prisma.message.create({
+      data: { senderId, receiverId, content },
+    });
+  }
+
+  async getLastMessageBetween(userA: number, userB: number): Promise<Message | null> {
+    return this.prisma.message.findFirst({
+      where: {
+        OR: [
+          { senderId: userA, receiverId: userB },
+          { senderId: userB, receiverId: userA },
+        ],
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, OnModuleInit, INestApplication } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test",
+    "**/*spec.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2018",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  }
+}


### PR DESCRIPTION
## Summary
- initialize a basic NestJS project structure
- add Prisma schema for users and messages
- provide starter README with features and instructions
- configure package.json scripts and dependencies
- add TypeScript configs and gitignore

## Testing
- `npm run build` *(fails: Cannot find module '@nestjs/common')*

------
https://chatgpt.com/codex/tasks/task_e_685a540958a08332abb4875db0fd62c7