### PR TITLE
Introduce structured config using ConfigModule

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+PORT=3000
+DATABASE_URL=postgresql://user:password@localhost:5432/database
+REDIS_URL=redis://localhost:6379

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run the development server:
 npm run start:dev
 ```
 
-Environment variables can be configured in a `.env` file. See `prisma/schema.prisma` for the `DATABASE_URL`.
+Environment variables can be configured in a `.env` file. A sample is provided in `.env.example`. See `prisma/schema.prisma` for the `DATABASE_URL`.
 
 The WebSocket gateway can scale horizontally when Redis is available. Set the
 `REDIS_URL` environment variable (defaults to `redis://localhost:6379`) to

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@nestjs/common": "latest",
+        "@nestjs/config": "^4.0.2",
         "@nestjs/core": "latest",
         "@nestjs/platform-express": "latest",
         "@nestjs/platform-socket.io": "^11.1.3",
@@ -101,6 +102,21 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.2.tgz",
+      "integrity": "sha512-McMW6EXtpc8+CwTUwFdg6h7dYcBUpH5iUILCclAsa+MbCEvC9ZKu4dCHRlJqALuhjLw97pbQu62l4+wRwGeZqA==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "16.4.7",
+        "dotenv-expand": "12.0.1",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
       }
     },
     "node_modules/@nestjs/core": {
@@ -793,6 +809,33 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.1.tgz",
+      "integrity": "sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1364,6 +1407,12 @@
       "engines": {
         "node": ">=13.2.0"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/make-error": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "type": "commonjs",
   "dependencies": {
     "@nestjs/common": "latest",
+    "@nestjs/config": "^4.0.2",
     "@nestjs/core": "latest",
     "@nestjs/platform-express": "latest",
     "@nestjs/platform-socket.io": "^11.1.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,19 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { Config } from './config';
 import { ChatModule } from './chat/chat.module';
 import { PrismaModule } from './prisma/prisma.module';
+import { RedisModule } from './redis/redis.module';
 
 @Module({
-  imports: [ChatModule, PrismaModule],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: Config,
+    }),
+    ChatModule,
+    PrismaModule,
+    RedisModule,
+  ],
 })
 export class AppModule {}

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -1,0 +1,5 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('app', () => ({
+  port: parseInt(process.env.PORT ?? '3000', 10),
+}));

--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -1,0 +1,5 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('database', () => ({
+  url: process.env.DATABASE_URL,
+}));

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,5 @@
+import appConfig from './app.config';
+import redisConfig from './redis.config';
+import databaseConfig from './database.config';
+
+export const Config = [appConfig, redisConfig, databaseConfig];

--- a/src/config/redis.config.ts
+++ b/src/config/redis.config.ts
@@ -1,0 +1,5 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('redis', () => ({
+  url: process.env.REDIS_URL ?? 'redis://localhost:6379',
+}));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,14 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { RedisIoAdapter } from './redis/redis.adapter';
+import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  const redisAdapter = new RedisIoAdapter();
+  const redisAdapter = app.get(RedisIoAdapter);
   await redisAdapter.connectToRedis();
   app.useWebSocketAdapter(redisAdapter);
-  await app.listen(3000);
+  const configService = app.get(ConfigService);
+  await app.listen(configService.get<number>('app.port'));
 }
 bootstrap();

--- a/src/redis/redis.adapter.ts
+++ b/src/redis/redis.adapter.ts
@@ -1,13 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { ServerOptions } from 'socket.io';
 import { createClient } from 'redis';
 import { createAdapter } from '@socket.io/redis-adapter';
 
+@Injectable()
 export class RedisIoAdapter extends IoAdapter {
   private adapterConstructor: ReturnType<typeof createAdapter> | undefined;
 
+  constructor(private configService: ConfigService) {
+    super();
+  }
+
   async connectToRedis(): Promise<void> {
-    const url = process.env.REDIS_URL || 'redis://localhost:6379';
+    const url = this.configService.get<string>('redis.url');
     const pubClient = createClient({ url });
     const subClient = pubClient.duplicate();
     await Promise.all([pubClient.connect(), subClient.connect()]);

--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { RedisIoAdapter } from './redis.adapter';
+
+@Module({
+  providers: [RedisIoAdapter],
+  exports: [RedisIoAdapter],
+})
+export class RedisModule {}


### PR DESCRIPTION
## Summary
- add global configuration setup with `@nestjs/config`
- create config files using `registerAs`
- make Redis adapter injectable and configurable
- load configuration in `AppModule`
- update bootstrap to use injected adapter and port
- document `.env.example` usage

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b625239b08332a4c05bfe215a9b65